### PR TITLE
fix: The Component 'BlogOverviewComponent' is declared by more than o…

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -13,12 +13,11 @@ import { HeaderComponent } from './header/header.component';
 import { MenuComponent } from './menu/menu.component';
 import { NavbarComponent } from './navbar/navbar.component';
 import { HttpClientModule } from '@angular/common/http';
-import { BlogPreviewComponent } from './blog-preview/blog-preview.component';
 import { PublicationsComponent } from './publications/publications.component';
-import { BlogOverviewComponent } from './blog-overview/blog-overview.component';
 import { ImpressumComponent } from './impressum/impressum.component';
 import { HighlightService } from './highlight.service';
 import { TwitterTimelineComponent } from './twitter-timeline/twitter-timeline.component';
+import { SharedModule } from './shared.module';
 
 @NgModule({
   declarations: [
@@ -29,9 +28,8 @@ import { TwitterTimelineComponent } from './twitter-timeline/twitter-timeline.co
     HeaderComponent,
     MenuComponent,
     NavbarComponent,
-    BlogPreviewComponent,
+
     PublicationsComponent,
-    BlogOverviewComponent,
     ImpressumComponent,
     TwitterTimelineComponent,
   ],
@@ -41,6 +39,7 @@ import { TwitterTimelineComponent } from './twitter-timeline/twitter-timeline.co
     HttpClientModule,
     A11yModule,
     NgxTwitterTimelineModule,
+    SharedModule,
   ],
   providers: [ScullyRoutesService, HighlightService],
   bootstrap: [AppComponent],

--- a/src/app/blog/blog.module.ts
+++ b/src/app/blog/blog.module.ts
@@ -4,9 +4,10 @@ import { ComponentsModule } from '@scullyio/ng-lib';
 import { BlogRoutingModule } from './blog-routing.module';
 import { BlogComponent } from './blog.component';
 import { BlogOverviewComponent } from '../blog-overview/blog-overview.component';
+import { SharedModule } from '../shared.module';
 
 @NgModule({
   declarations: [BlogComponent, BlogOverviewComponent],
-  imports: [CommonModule, BlogRoutingModule, ComponentsModule],
+  imports: [SharedModule, BlogRoutingModule, ComponentsModule],
 })
 export class BlogModule {}

--- a/src/app/shared.module.ts
+++ b/src/app/shared.module.ts
@@ -1,0 +1,14 @@
+// SharedModule is imported into `layout-modules` and any feature module lazy loaded into `layout-modules`
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { BlogPreviewComponent } from './blog-preview/blog-preview.component';
+import {  RouterModule } from '@angular/router';
+@NgModule({
+  imports: [CommonModule, RouterModule],
+  declarations: [BlogPreviewComponent],
+  exports: [
+    CommonModule,
+    BlogPreviewComponent,
+  ]
+})
+export class SharedModule {}


### PR DESCRIPTION
I get the following error when running `npm run build --prod` 

```
ERROR in src/app/blog-overview/blog-overview.component.ts:9:14 - error TS-996007: The Component 'BlogOverviewComponent' is declared by more than one NgModule.

9 export class BlogOverviewComponent implements OnInit {
               ~~~~~~~~~~~~~~~~~~~~~

  src/app/blog/blog.module.ts:9:33
    9   declarations: [BlogComponent, BlogOverviewComponent],
                                      ~~~~~~~~~~~~~~~~~~~~~
    'BlogOverviewComponent' is listed in the declarations of the NgModule 'BlogModule'.
  src/app/app.module.ts:34:5
    34     BlogOverviewComponent,
           ~~~~~~~~~~~~~~~~~~~~~
    'BlogOverviewComponent' is listed in the declarations of the NgModule 'AppModule'.
```